### PR TITLE
Add 3D canvas background and dark theme

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,6 +1,6 @@
 body {
-    background-color: #f8f9fa;
-    color: #222;
+    background-color: #111;
+    color: #eee;
     font-family: Arial, Helvetica, sans-serif;
 }
 #header {
@@ -13,6 +13,6 @@ body {
     color: #ffd700;
 }
 #intro {
-    background: linear-gradient(135deg, #8f94fb, #4e54c8);
+    background: linear-gradient(135deg, #1f1f1f, #111);
     color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 		  </style>
 	</head>
 	<body class="is-preload">
+        <canvas id="bg" style="position:fixed;top:0;left:0;width:100%;height:100%;z-index:-1;"></canvas>
 
 		<!-- Wrapper -->
 			<div id="wrapper" class="fade-in">
@@ -130,6 +131,30 @@
 			<script src="assets/js/breakpoints.min.js"></script>
 			<script src="assets/js/util.js"></script>
 			<script src="assets/js/main.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+        <script>
+            const scene = new THREE.Scene();
+            const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+            const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById("bg"), alpha: true });
+            renderer.setSize(window.innerWidth, window.innerHeight);
+            window.addEventListener("resize", () => {
+                camera.aspect = window.innerWidth / window.innerHeight;
+                camera.updateProjectionMatrix();
+                renderer.setSize(window.innerWidth, window.innerHeight);
+            });
+            const geometry = new THREE.BoxGeometry();
+            const material = new THREE.MeshNormalMaterial();
+            const cube = new THREE.Mesh(geometry, material);
+            scene.add(cube);
+            camera.position.z = 2;
+            function animate() {
+                requestAnimationFrame(animate);
+                cube.rotation.x += 0.01;
+                cube.rotation.y += 0.01;
+                renderer.render(scene, camera);
+            }
+            animate();
+        </script>
 
 		</body>
 </html>


### PR DESCRIPTION
## Summary
- modernize the site style with a darker palette
- include a Three.js canvas background that shows a rotating cube

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ab2f3240832fb6d81fcdfdc6cf3e